### PR TITLE
[FIX] Fix an issue about model name (product.image) conflict

### DIFF
--- a/storage_backend/views/backend_storage_view.xml
+++ b/storage_backend/views/backend_storage_view.xml
@@ -1,79 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-<record id="storage_backend_view_tree" model="ir.ui.view">
-    <field name="model">storage.backend</field>
-    <field name="arch" type="xml">
-        <tree string="Storage Backend">
-            <field name="name"/>
-            <field name="backend_type" />
-        </tree>
-    </field>
-</record>
+    <record id="storage_backend_view_tree" model="ir.ui.view">
+        <field name="model">storage.backend</field>
+        <field name="arch" type="xml">
+            <tree string="Storage Backend">
+                <field name="name"/>
+                <field name="backend_type" />
+            </tree>
+        </field>
+    </record>
 
-<record id="storage_backend_view_form" model="ir.ui.view">
-    <field name="model">storage.backend</field>
-    <field name="arch" type="xml">
-        <form string="Storage Backend">
-            <sheet>
-                <div class="oe_title">
-                    <label for="name" class="oe_edit_only"/>
-                    <h1>
-                        <field name="name"/>
-                    </h1>
-                </div>
-                <group name="config">
-                    <field name="backend_type"/>
-                    <field name="directory_path"/>
-                </group>
-            </sheet>
-        </form>
-    </field>
-</record>
+    <record id="storage_backend_view_form" model="ir.ui.view">
+        <field name="model">storage.backend</field>
+        <field name="arch" type="xml">
+            <form string="Storage Backend">
+                <sheet>
+                    <div class="oe_title">
+                        <label for="name" class="oe_edit_only"/>
+                        <h1>
+                            <field name="name"/>
+                        </h1>
+                    </div>
+                    <group name="config">
+                        <field name="backend_type"/>
+                        <field name="directory_path"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
 
-<record id="storage_backend_view_search" model="ir.ui.view">
-    <field name="model">storage.backend</field>
-    <field name="arch" type="xml">
-        <search string="Storage Backend">
-            <field name="name"/>
-        </search>
-    </field>
-</record>
+    <record id="storage_backend_view_search" model="ir.ui.view">
+        <field name="model">storage.backend</field>
+        <field name="arch" type="xml">
+            <search string="Storage Backend">
+                <field name="name"/>
+            </search>
+        </field>
+    </record>
 
-<record model="ir.actions.act_window" id="act_open_storage_backend_view">
-    <field name="name">Storage Backend</field>
-    <field name="type">ir.actions.act_window</field>
-    <field name="res_model">storage.backend</field>
-    <field name="view_type">form</field>
-    <field name="view_mode">tree,form</field>
-    <field name="search_view_id" ref="storage_backend_view_search"/>
-    <field name="domain">[]</field>
-    <field name="context">{}</field>
-</record>
+    <record model="ir.actions.act_window" id="act_open_storage_backend_view">
+        <field name="name">Storage Backend</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">storage.backend</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="storage_backend_view_search"/>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
 
-<record model="ir.actions.act_window.view" id="act_open_storage_backend_view_form">
-    <field name="act_window_id" ref="act_open_storage_backend_view"/>
-    <field name="sequence" eval="20"/>
-    <field name="view_mode">form</field>
-    <field name="view_id" ref="storage_backend_view_form"/>
-</record>
+    <record model="ir.actions.act_window.view" id="act_open_storage_backend_view_form">
+        <field name="act_window_id" ref="act_open_storage_backend_view"/>
+        <field name="sequence" eval="20"/>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="storage_backend_view_form"/>
+    </record>
 
-<record model="ir.actions.act_window.view" id="act_open_storage_backend_view_tree">
-    <field name="act_window_id" ref="act_open_storage_backend_view"/>
-    <field name="sequence" eval="10"/>
-    <field name="view_mode">tree</field>
-    <field name="view_id" ref="storage_backend_view_tree"/>
-</record>
+    <record model="ir.actions.act_window.view" id="act_open_storage_backend_view_tree">
+        <field name="act_window_id" ref="act_open_storage_backend_view"/>
+        <field name="sequence" eval="10"/>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="storage_backend_view_tree"/>
+    </record>
 
 
-<menuitem id="menu_storage"
-    parent="base.menu_custom"
-    sequence="100"
-    action="act_open_storage_backend_view"/>
+    <menuitem id="menu_storage"
+              parent="base.menu_custom"
+              sequence="100"
+              action="act_open_storage_backend_view"/>
 
-<menuitem id="menu_storage_backend"
-    parent="menu_storage"
-    sequence="10"
-    action="act_open_storage_backend_view"/>
+    <menuitem id="menu_storage_backend"
+              parent="menu_storage"
+              sequence="10"
+              action="act_open_storage_backend_view"/>
 
 </odoo>

--- a/storage_file/views/storage_backend_view.xml
+++ b/storage_file/views/storage_backend_view.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openerp>
-    <data>
-
-<record id="storage_backend_view_form" model="ir.ui.view">
-    <field name="model">storage.backend</field>
-    <field name="inherit_id" ref="storage_backend.storage_backend_view_form"/>
-    <field name="arch" type="xml">
-        <field name="backend_type" position="after">
-            <field name="served_by"/>
-            <field name="base_url"
-                attrs="{'invisible':[('served_by', '!=', 'external')]}"/>
-            <field name="filename_strategy"/>
+<odoo>
+    <record id="storage_backend_view_form" model="ir.ui.view">
+        <field name="model">storage.backend</field>
+        <field name="inherit_id" ref="storage_backend.storage_backend_view_form"/>
+        <field name="arch" type="xml">
+            <field name="backend_type" position="after">
+                <field name="served_by"/>
+                <field name="base_url"
+                    attrs="{'invisible':[('served_by', '!=', 'external')]}"/>
+                <field name="filename_strategy"/>
+            </field>
         </field>
-    </field>
-</record>
-
-    </data>
-</openerp>
+    </record>
+</odoo>

--- a/storage_image/models/storage_file.py
+++ b/storage_image/models/storage_file.py
@@ -3,7 +3,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import fields, models
+from odoo import fields, models
 
 
 class StorageFile(models.Model):

--- a/storage_image/tests/test_storage_image.py
+++ b/storage_image/tests/test_storage_image.py
@@ -61,6 +61,26 @@ class StorageImageCase(TransactionComponentCase):
         self.assertIsNotNone(image.image_small_url)
         self._check_thumbnail(image)
 
+    def test_create_specific_thumbnail(self):
+        image = self._create_storage_image()
+        thumbnail = image.get_or_create_thumbnail(
+            100, 100, u'my-image-thumbnail')
+        self.assertEqual(thumbnail.url_key, u'my-image-thumbnail')
+        self.assertEqual(
+            thumbnail.relative_path[0:26],
+            u'my-image-thumbnail_100_100')
+
+        # Check that method will return the same thumbnail
+        # Check also that url_key have been slugified
+        new_thumbnail = image.get_or_create_thumbnail(
+            100, 100, u'My Image Thumbnail')
+        self.assertEqual(new_thumbnail.id, thumbnail.id)
+
+        # Check that method will return a new thumbnail
+        new_thumbnail = image.get_or_create_thumbnail(
+            100, 100, u'My New Image Thumbnail')
+        self.assertNotEqual(new_thumbnail.id, thumbnail.id)
+
     def test_name_onchange(self):
         image = self.env['storage.image'].new({
             'name': 'Test-of image_name.png'})

--- a/storage_image_product/__manifest__.py
+++ b/storage_image_product/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Storage Image Product",
     "summary": "Link images to products and categories",
-    "version": "10.0.1.0.0",
+    "version": "10.0.2.0.0",
     "category": "Storage",
     "website": "www.akretion.com",
     "author": " Akretion",
@@ -20,7 +20,7 @@
     "data": [
         "security/ir.model.access.csv",
         "views/product_template.xml",
-        "views/product_image.xml",
+        "views/product_image_relation.xml",
         "views/product_product.xml",
         "views/product_category.xml",
         "views/image_tag.xml",

--- a/storage_image_product/migrations/10.0.2.0.0/pre-migration.py
+++ b/storage_image_product/migrations/10.0.2.0.0/pre-migration.py
@@ -23,5 +23,11 @@ def migrate(cr, version):
                     "RENAME TO product_image_relation;"
     query_category = "ALTER TABLE category_image " \
                      "RENAME TO category_image_relation;"
+    query_seq_product = "ALTER SEQUENCE product_image_id_seq " \
+                        "RENAME TO product_image_relation_id_seq;"
+    query_seq_categ = "ALTER SEQUENCE category_image_id_seq " \
+                      "RENAME TO category_image_relation_id_seq;"
     cr.execute(query_product)
     cr.execute(query_category)
+    cr.execute(query_seq_product)
+    cr.execute(query_seq_categ)

--- a/storage_image_product/migrations/10.0.2.0.0/pre-migration.py
+++ b/storage_image_product/migrations/10.0.2.0.0/pre-migration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
 def migrate(cr, version):

--- a/storage_image_product/migrations/10.0.2.0.0/pre-migration.py
+++ b/storage_image_product/migrations/10.0.2.0.0/pre-migration.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    """
+    Change of this 10.0.2 version:
+    - Rename product.image into product.image.relation because website_sale
+    module already have the same model;
+    - Apply the same logic on the category.image (renamed into
+    category.image.relation).
+    If this module is installed, it means that website_sale module is not
+    installed (otherwise, we already have an issue).
+    So this migration script doesn't check if website_sale is installed.
+    :param cr: database cursor
+    :param version: str
+    :return:
+    """
+    if not version:
+        return
+    query_product = "ALTER TABLE product_image " \
+                    "RENAME TO product_image_relation;"
+    query_category = "ALTER TABLE category_image " \
+                     "RENAME TO category_image_relation;"
+    cr.execute(query_product)
+    cr.execute(query_category)

--- a/storage_image_product/models/__init__.py
+++ b/storage_image_product/models/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from . import product_image
+from . import product_image_relation
 from . import product_template
 from . import product_product
 from . import product_category
-from . import category_image
+from . import category_image_relation
 from . import image_tag

--- a/storage_image_product/models/category_image_relation.py
+++ b/storage_image_product/models/category_image_relation.py
@@ -10,8 +10,8 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-class CategoryImage(models.Model):
-    _name = "category.image"
+class CategoryImageRelation(models.Model):
+    _name = "category.image.relation"
 
     image_id = fields.Many2one(
         'storage.image',

--- a/storage_image_product/models/product_category.py
+++ b/storage_image_product/models/product_category.py
@@ -14,6 +14,6 @@ class ProductCategory(models.Model):
     _inherit = 'product.category'
 
     image_ids = fields.One2many(
-        'category.image',
+        'category.image.relation',
         inverse_name='category_id',
     )

--- a/storage_image_product/models/product_image_relation.py
+++ b/storage_image_product/models/product_image_relation.py
@@ -10,8 +10,8 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-class ProductImage(models.Model):
-    _name = 'product.image'
+class ProductImageRelation(models.Model):
+    _name = 'product.image.relation'
     _order = 'sequence, image_id'
 
     sequence = fields.Integer()

--- a/storage_image_product/models/product_product.py
+++ b/storage_image_product/models/product_product.py
@@ -18,14 +18,14 @@ class ProductProduct(models.Model):
         related='variant_image_ids.image_id.image_medium_url',
         store=True)
     variant_image_ids = fields.Many2many(
-        'product.image',
+        'product.image.relation',
         compute="_compute_variant_image_ids",
         store=True)
 
     @api.depends('product_tmpl_id.image_ids', 'attribute_value_ids')
     def _compute_variant_image_ids(self):
         for variant in self:
-            res = self.env['product.image'].browse([])
+            res = self.env['product.image.relation'].browse([])
             for image in variant.image_ids:
                 if not (image.attribute_value_ids -
                         variant.attribute_value_ids):

--- a/storage_image_product/models/product_product.py
+++ b/storage_image_product/models/product_product.py
@@ -3,7 +3,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import api, fields, models
+from odoo import api, fields, models
 
 
 class ProductProduct(models.Model):

--- a/storage_image_product/models/product_template.py
+++ b/storage_image_product/models/product_template.py
@@ -22,6 +22,6 @@ class ProductTemplate(models.Model):
         related='image_ids.image_id.image_medium_url',
         store=True)
     image_ids = fields.One2many(
-        'product.image',
+        'product.image.relation',
         inverse_name='product_tmpl_id',
     )

--- a/storage_image_product/security/ir.model.access.csv
+++ b/storage_image_product/security/ir.model.access.csv
@@ -1,7 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_product_image_edit,product_image edit,model_product_image,storage_image.group_image_manager,1,1,1,1
-access_product_image_read,product_image read,model_product_image,base.group_user,1,0,0,0
-access_category_image_edit,category_image edit,model_category_image,storage_image.group_image_manager,1,1,1,1
-access_category_image_read,category_image read,model_category_image,base.group_user,1,0,0,0
+access_product_image_edit,product_image edit,model_product_image_relation,storage_image.group_image_manager,1,1,1,1
+access_product_image_read,product_image read,model_product_image_relation,base.group_user,1,0,0,0
+access_category_image_edit,category_image edit,model_category_image_relation,storage_image.group_image_manager,1,1,1,1
+access_category_image_read,category_image read,model_category_image_relation,base.group_user,1,0,0,0
 access_image_tag_edit,image_tag edit,model_image_tag,base.group_erp_manager,1,1,1,1
 access_image_tag_read,image_tag read,model_image_tag,base.group_user,1,0,0,0

--- a/storage_image_product/tests/__init__.py
+++ b/storage_image_product/tests/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from . import test_product_image
+from . import test_product_image_relation

--- a/storage_image_product/tests/test_product_image_relation.py
+++ b/storage_image_product/tests/test_product_image_relation.py
@@ -40,13 +40,13 @@ class ProductImageCase(TransactionComponentCase):
     def test_available_attribute_value(self):
         # The template have already 5 attribute values
         # see demo data of ipad
-        image = self.env['product.image'].new({
+        image = self.env['product.image.relation'].new({
             'product_tmpl_id': self.template.id})
         self.assertEqual(len(image.available_attribute_value_ids), 5)
 
     def test_add_image_for_all_variant(self):
         self.assertEqual(len(self.product_a.variant_image_ids), 0)
-        image = self.env['product.image'].create({
+        image = self.env['product.image.relation'].create({
             'product_tmpl_id': self.template.id,
             'image_id': self.logo_image.id,
             })
@@ -55,7 +55,7 @@ class ProductImageCase(TransactionComponentCase):
         self.assertEqual(self.product_c.variant_image_ids, image)
 
     def test_add_image_for_white_variant(self):
-        image = self.env['product.image'].create({
+        image = self.env['product.image.relation'].create({
             'product_tmpl_id': self.template.id,
             'image_id': self.white_image.id,
             'attribute_value_ids': [(6, 0, [self.env.ref(
@@ -68,17 +68,17 @@ class ProductImageCase(TransactionComponentCase):
         self.assertEqual(len(self.product_b.variant_image_ids), 0)
 
     def test_add_image_for_white_and_black_variant(self):
-        logo = self.env['product.image'].create({
+        logo = self.env['product.image.relation'].create({
             'product_tmpl_id': self.template.id,
             'image_id': self.logo_image.id,
             })
-        image_wh = self.env['product.image'].create({
+        image_wh = self.env['product.image.relation'].create({
             'product_tmpl_id': self.template.id,
             'image_id': self.white_image.id,
             'attribute_value_ids': [(6, 0, [self.env.ref(
                 'product.product_attribute_value_3').id])]
             })
-        image_bk = self.env['product.image'].create({
+        image_bk = self.env['product.image.relation'].create({
             'product_tmpl_id': self.template.id,
             'image_id': self.black_image.id,
             'attribute_value_ids': [(6, 0, [self.env.ref(

--- a/storage_image_product/views/product_category.xml
+++ b/storage_image_product/views/product_category.xml
@@ -12,8 +12,8 @@
     </record>
 
 
-    <record id="product_category_image_form" model="ir.ui.view">
-        <field name="model">category.image</field>
+    <record id="product_category_image_relation_form" model="ir.ui.view">
+        <field name="model">category.image.relation</field>
         <field name="arch" type="xml">
             <form string="Association">
                 <group>
@@ -25,8 +25,8 @@
     </record>
 
 
-    <record id="product_category_image_kanban" model="ir.ui.view">
-        <field name="model">category.image</field>
+    <record id="product_category_image_relation_kanban" model="ir.ui.view">
+        <field name="model">category.image.relation</field>
         <field name="arch" type="xml">
             <kanban>
                 <field name="image_name" />

--- a/storage_image_product/views/product_image_relation.xml
+++ b/storage_image_product/views/product_image_relation.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-    <record id="product_image_form" model="ir.ui.view">
-        <field name="model">product.image</field>
+    <record id="product_image_relation_form" model="ir.ui.view">
+        <field name="model">product.image.relation</field>
         <field name="arch" type="xml">
             <form string="Association">
                 <group>
@@ -20,8 +20,8 @@
         </field>
     </record>
 
-    <record id="product_image_kanban" model="ir.ui.view">
-        <field name="model">product.image</field>
+    <record id="product_image_relation_kanban" model="ir.ui.view">
+        <field name="model">product.image.relation</field>
         <field name="arch" type="xml">
             <kanban>
                 <field name="image_name"/>

--- a/storage_image_product/views/product_product.xml
+++ b/storage_image_product/views/product_product.xml
@@ -1,44 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-<record id="product_kanban_view" model="ir.ui.view">
-    <field name="model">product.product</field>
-    <field name="inherit_id" ref="product.product_kanban_view"/>
-    <field name="priority" eval="32"/>
-    <field name="arch" type="xml">
-        <field name="image_small" position="replace">
-            <field name="variant_image_small_url" widget="image_url" class="oe_avatar"/>
+    <record id="product_kanban_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_kanban_view"/>
+        <field name="priority" eval="32"/>
+        <field name="arch" type="xml">
+            <field name="image_small" position="replace">
+                <field name="image_small" invisible="True"/>
+                <field name="variant_image_small_url" widget="image_url" class="oe_avatar"/>
+            </field>
+            <xpath expr="//div[@class='o_kanban_image']/img" position="replace">
+                <img t-att-src="record.variant_image_small_url.value"/>
+            </xpath>
         </field>
-        <xpath expr="//div[@class='o_kanban_image']/img" position="replace">
-            <img t-att-src="record.variant_image_small_url.value"/>
-        </xpath>
-    </field>
-</record>
+    </record>
 
 
-<record id="product_normal_form_view" model="ir.ui.view">
-    <field name="model">product.product</field>
-    <field name="inherit_id" ref="product.product_normal_form_view"/>
-    <field name="arch" type="xml">
-        <field name="image_medium" position="replace">
-            <field name="variant_image_medium_url" widget="image_url" class="oe_avatar"/>
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="arch" type="xml">
+            <field name="image_medium" position="replace">
+                <field name="image_medium" invisible="True"/>
+                <field name="variant_image_medium_url" widget="image_url" class="oe_avatar"/>
+            </field>
+            <xpath expr="//page[@name='sales']" position="after">
+                <page name="image" string="Image">
+                    <field name="variant_image_ids" mode="kanban"/>
+                </page>
+            </xpath>
         </field>
-        <xpath expr="//page[@name='sales']" position="after">
-            <page name="image" string="Image">
-                <field name="variant_image_ids" mode="kanban"/>
-            </page>
-        </xpath>
-    </field>
-</record>
+    </record>
 
-<record id="product_variant_easy_edit_view" model="ir.ui.view">
-    <field name="model">product.product</field>
-    <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
-    <field name="arch" type="xml">
-        <field name="image_medium" position="replace">
-            <field name="variant_image_medium_url" widget="image_url" class="oe_avatar"/>
+    <record id="product_variant_easy_edit_view" model="ir.ui.view">
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+        <field name="arch" type="xml">
+            <field name="image_medium" position="replace">
+                <field name="image_medium" invisible="True"/>
+                <field name="variant_image_medium_url" widget="image_url" class="oe_avatar"/>
+            </field>
         </field>
-    </field>
-</record>
+    </record>
 
 </odoo>

--- a/storage_image_product/views/product_template.xml
+++ b/storage_image_product/views/product_template.xml
@@ -7,6 +7,7 @@
         <field name="priority" eval="32"/>
         <field name="arch" type="xml">
             <field name="image_medium" position="replace">
+                <field name="image_medium" invisible="True"/>
                 <field name="image_medium_url" widget="image_url" class="oe_avatar"/>
             </field>
             <xpath expr="//page[@name='sales']" position="after">
@@ -23,6 +24,7 @@
         <field name="priority" eval="32"/>
         <field name="arch" type="xml">
             <field name="image_small" position="replace">
+                <field name="image_small" invisible="True"/>
                 <field name="image_small_url" widget="image_url" class="oe_avatar"/>
             </field>
             <xpath expr="//div[@class='o_kanban_image']/img" position="replace">

--- a/storage_thumbnail/models/storage_file.py
+++ b/storage_thumbnail/models/storage_file.py
@@ -3,7 +3,7 @@
 # @author Sébastien BEAU <sebastien.beau@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import fields, models
+from odoo import fields, models
 
 
 class StorageFile(models.Model):

--- a/storage_thumbnail/models/storage_thumbnail.py
+++ b/storage_thumbnail/models/storage_thumbnail.py
@@ -17,6 +17,10 @@ class StorageThumbnail(models.Model):
 
     size_x = fields.Integer("weight")
     size_y = fields.Integer("height")
+    alt_name = fields.Char(
+        "Alt Image name",
+        help="Alt name of the picture",
+    )
     file_id = fields.Many2one(
         'storage.file',
         'File',
@@ -29,7 +33,7 @@ class StorageThumbnail(models.Model):
         readonly=False,
         index=True)
 
-    def _prepare_thumbnail(self, image, size_x, size_y):
+    def _prepare_thumbnail(self, image, size_x, size_y, alt_name=''):
         return {
             'data': self._resize(image, size_x, size_y),
             'res_model': image._name,
@@ -38,13 +42,14 @@ class StorageThumbnail(models.Model):
                 image.filename, size_x, size_y, image.extension),
             'size_x': size_x,
             'size_y': size_y,
+            'alt_name': alt_name,
         }
 
     def _resize(self, image, size_x, size_y):
         return image_resize_image(image.data, size=(size_x, size_y))
 
-    def _create_thumbnail(self, image, size_x, size_y):
-        vals = self._prepare_thumbnail(image, size_x, size_y)
+    def _create_thumbnail(self, image, size_x, size_y, alt_name):
+        vals = self._prepare_thumbnail(image, size_x, size_y, alt_name)
         return self.create(vals)
 
     def _get_backend_id(self):
@@ -66,6 +71,6 @@ class StorageThumbnail(models.Model):
 
     def unlink(self):
         files = self.mapped('file_id')
-        super(StorageThumbnail, self).unlink()
+        result = super(StorageThumbnail, self).unlink()
         files.unlink()
-        return True
+        return result

--- a/storage_thumbnail/models/storage_thumbnail.py
+++ b/storage_thumbnail/models/storage_thumbnail.py
@@ -17,9 +17,9 @@ class StorageThumbnail(models.Model):
 
     size_x = fields.Integer("weight")
     size_y = fields.Integer("height")
-    alt_name = fields.Char(
-        "Alt Image name",
-        help="Alt name of the picture",
+    url_key = fields.Char(
+        "Url key",
+        help="Specific URL key for generating the url of the image",
     )
     file_id = fields.Many2one(
         'storage.file',
@@ -33,23 +33,26 @@ class StorageThumbnail(models.Model):
         readonly=False,
         index=True)
 
-    def _prepare_thumbnail(self, image, size_x, size_y, alt_name=''):
+    def _prepare_thumbnail(self, image, size_x, size_y, url_key):
         return {
             'data': self._resize(image, size_x, size_y),
             'res_model': image._name,
             'res_id': image.id,
             'name': '%s_%s_%s%s' % (
-                image.filename, size_x, size_y, image.extension),
+                url_key or image.filename,
+                size_x,
+                size_y,
+                image.extension),
             'size_x': size_x,
             'size_y': size_y,
-            'alt_name': alt_name,
+            'url_key': url_key,
         }
 
     def _resize(self, image, size_x, size_y):
         return image_resize_image(image.data, size=(size_x, size_y))
 
-    def _create_thumbnail(self, image, size_x, size_y, alt_name):
-        vals = self._prepare_thumbnail(image, size_x, size_y, alt_name)
+    def _create_thumbnail(self, image, size_x, size_y, url_key):
+        vals = self._prepare_thumbnail(image, size_x, size_y, url_key)
         return self.create(vals)
 
     def _get_backend_id(self):

--- a/storage_thumbnail/views/storage_thumbnail_view.xml
+++ b/storage_thumbnail/views/storage_thumbnail_view.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-        <record id="view_thumbnail_form" model="ir.ui.view">
-            <field name="model">storage.thumbnail</field>
-            <field name="arch" type="xml">
-                <form string="Thumgnail">
-                    <group>
-                        <field name="size_x" />
-                        <field name="size_y" />
-                    </group>
-                </form>
-            </field>
-        </record>
-
-        <record id="view_thumbnail_tree" model="ir.ui.view">
-            <field name="model">storage.thumbnail</field>
-            <field name="arch" type="xml">
-                <tree string="Thumgnail">
-                    <field name="name" />
+    <record id="view_thumbnail_form" model="ir.ui.view">
+        <field name="model">storage.thumbnail</field>
+        <field name="arch" type="xml">
+            <form string="Thumgnail">
+                <group>
+                    <field name="alt_name" />
                     <field name="size_x" />
                     <field name="size_y" />
-                </tree>
-            </field>
-        </record>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_thumbnail_tree" model="ir.ui.view">
+        <field name="model">storage.thumbnail</field>
+        <field name="arch" type="xml">
+            <tree string="Thumgnail">
+                <field name="name" />
+                <field name="alt_name" />
+                <field name="size_x" />
+                <field name="size_y" />
+            </tree>
+        </field>
+    </record>
 
 </odoo>

--- a/storage_thumbnail/views/storage_thumbnail_view.xml
+++ b/storage_thumbnail/views/storage_thumbnail_view.xml
@@ -4,9 +4,9 @@
     <record id="view_thumbnail_form" model="ir.ui.view">
         <field name="model">storage.thumbnail</field>
         <field name="arch" type="xml">
-            <form string="Thumgnail">
+            <form string="Thumbnail">
                 <group>
-                    <field name="alt_name" />
+                    <field name="url_key" />
                     <field name="size_x" />
                     <field name="size_y" />
                 </group>
@@ -19,7 +19,7 @@
         <field name="arch" type="xml">
             <tree string="Thumgnail">
                 <field name="name" />
-                <field name="alt_name" />
+                <field name="url_key" />
                 <field name="size_x" />
                 <field name="size_y" />
             </tree>


### PR DESCRIPTION
**Changes:**
- Fix an issue about model name (product.image) conflict when website_sale is installed (this standard module have a same model);
- Replace `openerp` by `odoo`;
- Re-indent some xml file;
- Add alt_name field on thumbnail;
- Into inherited views, change some field replaced.