### PR TITLE
[10.0][ADD] Public backend.storage (+ related files)

### DIFF
--- a/storage_file/__manifest__.py
+++ b/storage_file/__manifest__.py
@@ -24,6 +24,7 @@
         'views/storage_file_view.xml',
         'views/storage_backend_view.xml',
         'security/ir.model.access.csv',
+        'security/storage_file.xml',
         'data/ir_cron.xml',
     ],
     "demo": [

--- a/storage_file/models/storage_backend.py
+++ b/storage_file/models/storage_backend.py
@@ -31,3 +31,12 @@ class StorageBackend(models.Model):
         required=True,
         default='odoo')
     base_url = fields.Char()
+    is_public = fields.Boolean(
+        default=False,
+        help="Define if every files stored into this backend are "
+             "public or not. Examples:\n"
+             "Private: your file/image can not be displayed is the user is "
+             "not logged (not available on other website);\n"
+             "Public: your file/image can be displayed if nobody is "
+             "logged (useful to display files on external websites)",
+    )

--- a/storage_file/security/ir.model.access.csv
+++ b/storage_file/security/ir.model.access.csv
@@ -1,4 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_storage_file_edit,storage_file edit,model_storage_file,base.group_system,1,1,1,1
-access_storage_file_read,storage_file read,model_storage_file,base.group_user,1,0,0,0
-access_storage_file_read_public,storage_file public,model_storage_file,,1,0,0,0
+access_storage_file_read_public,storage_file public read,model_storage_file,,1,0,0,0

--- a/storage_file/security/ir.model.access.csv
+++ b/storage_file/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_storage_file_edit,storage_file edit,model_storage_file,base.group_system,1,1,1,1
 access_storage_file_read,storage_file read,model_storage_file,base.group_user,1,0,0,0
+access_storage_file_read_public,storage_file public,model_storage_file,,1,0,0,0

--- a/storage_file/security/storage_file.xml
+++ b/storage_file/security/storage_file.xml
@@ -6,7 +6,7 @@
     <record id="ir_rule_storage_file_public" model="ir.rule">
         <field name="name">Storage file public</field>
         <field name="model_id" ref="model_storage_file"/>
-        <field name="global" eval="True"/>
+        <field name="groups" eval="[(4, ref('base.group_public'))]"/>
         <field name="domain_force">[('backend_id.is_public', '=', True)]</field>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/storage_file/security/storage_file.xml
+++ b/storage_file/security/storage_file.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <!--Security rule to allow public access on storage.file (depending on the storage.backend)-->
+    <record id="ir_rule_storage_file_public" model="ir.rule">
+        <field name="name">Storage file public</field>
+        <field name="model_id" ref="model_storage_file"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">[('backend_id.is_public', '=', True)]</field>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+</odoo>

--- a/storage_file/views/storage_backend_view.xml
+++ b/storage_file/views/storage_backend_view.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <field name="backend_type" position="after">
                 <field name="served_by"/>
-                <field name="is_public"/>
+                <field name="is_public" attrs="{'invisible': [('served_by', '!=', 'odoo')]}"/>
                 <field name="base_url"
                     attrs="{'invisible':[('served_by', '!=', 'external')]}"/>
                 <field name="filename_strategy"/>

--- a/storage_file/views/storage_backend_view.xml
+++ b/storage_file/views/storage_backend_view.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <field name="backend_type" position="after">
                 <field name="served_by"/>
+                <field name="is_public"/>
                 <field name="base_url"
                     attrs="{'invisible':[('served_by', '!=', 'external')]}"/>
                 <field name="filename_strategy"/>

--- a/storage_image/tests/test_storage_image.py
+++ b/storage_image/tests/test_storage_image.py
@@ -32,7 +32,7 @@ class StorageImageCase(TransactionComponentCase):
         return self.env['storage.image'].create({
             'name': self.filename,
             'image_medium_url': self.filedata,
-            })
+        })
 
     def _check_thumbnail(self, image):
         self.assertEqual(len(image.thumbnail_ids), 2)


### PR DESCRIPTION
Actually, it's not possible to define a storage.file (contained into storage.backend) as a public data.
The new boolean field "is_public" on storage.backend let every content (storage.file) available as public data.
This new field is False as default value (for security reason).

Quick step to test:
(you must have only 1 DB for this test, otherwise controllers are confused)
- Setup your storage backend (is_public = True)
- Add a picture on product.template (and save)
- Copy the url of the picture (right click, "open picture on new tab");
- You have access to the storage.file (as a picture);
- Copy/paste this URL into a incognito window => You should have access;
- Edit your backend (is_public = False);
- Refresh your incognito window => You don't have access;
- Into your normal window, you keep your access to the file/image.