### PR TITLE
[IMP] storage_thumbnail: Improve performance by avoiding 1 search for…

### DIFF
--- a/storage_thumbnail/models/storage_thumbnail.py
+++ b/storage_thumbnail/models/storage_thumbnail.py
@@ -51,10 +51,6 @@ class StorageThumbnail(models.Model):
     def _resize(self, image, size_x, size_y):
         return image_resize_image(image.data, size=(size_x, size_y))
 
-    def _create_thumbnail(self, image, size_x, size_y, url_key):
-        vals = self._prepare_thumbnail(image, size_x, size_y, url_key)
-        return self.create(vals)
-
     def _get_backend_id(self):
         """Choose the correct backend.
 

--- a/storage_thumbnail/models/thumbnail_mixin.py
+++ b/storage_thumbnail/models/thumbnail_mixin.py
@@ -46,8 +46,12 @@ class ThumbnailMixing(models.AbstractModel):
                 thumbnail = th
                 break
         if not thumbnail and self.data:
-            thumbnail = self.env['storage.thumbnail']._create_thumbnail(
+            vals = self.env['storage.thumbnail']._prepare_thumbnail(
                 self, size_x, size_y, url_key)
+            # use the relation to create the thumbnail to be sure that the
+            # record is added to the cache of this relation.
+            self.write({'thumbnail_ids': [(0, 0, vals)]})
+            return self.get_or_create_thumbnail(size_x, size_y, url_key)
         return thumbnail
 
     def generate_odoo_thumbnail(self):


### PR DESCRIPTION
… each thumbnail to retrieve

This commit greatly reduces the number of queries to retrieve the product's thumbnails. In my test case used to debug perf issues, with this change, I went from 132 requests to 2 on storage.file.
For sure there are still a lot of places to improve...

Errors into travis are not related to these changes... 