### PR TITLE
[10.0][UPD] storage_image_product Add the little cross into kanban view 

### DIFF
--- a/storage_image_product/views/product_category.xml
+++ b/storage_image_product/views/product_category.xml
@@ -36,6 +36,7 @@
                 <templates>
                     <t t-name="kanban-box">
                         <div class="oe_kanban_vignette oe_semantic_html_override">
+                            <a t-if="! read_only_mode" type="delete" style="position: absolute; right: 0; padding: 4px; diplay: inline-block">X</a>
                             <a type="open">
                                 <img t-att-src="record.image_url.value"
                                      class="oe_kanban_image" />


### PR DESCRIPTION
Module `storage_image_product`: add little cross into kanban view to allow delete the category image relation