### PR TITLE
[10.0][REF] fix image UI

### DIFF
--- a/storage_image_product/__manifest__.py
+++ b/storage_image_product/__manifest__.py
@@ -12,7 +12,12 @@
     "author": " Akretion",
     "license": "AGPL-3",
     "installable": True,
-    "depends": ["storage_image", "product", "sale"],  # only for the menu
+    "depends": [
+        "storage_image",
+        "product",
+        "sale",
+        "web_tree_image",
+    ],  # only for the menu
     "data": [
         "security/ir.model.access.csv",
         "views/product_template.xml",

--- a/storage_image_product/models/category_image_relation.py
+++ b/storage_image_product/models/category_image_relation.py
@@ -14,6 +14,7 @@ _logger = logging.getLogger(__name__)
 class CategoryImageRelation(models.Model):
     _name = "category.image.relation"
 
+    sequence = fields.Integer()
     image_id = fields.Many2one("storage.image", required=True)
     category_id = fields.Many2one("product.category")
     tag_id = fields.Many2one(

--- a/storage_image_product/views/product_category.xml
+++ b/storage_image_product/views/product_category.xml
@@ -7,9 +7,22 @@
         <field name="arch" type="xml">
             <xpath expr="//group[last()]" position="after">
                 <group name="images" string="Images">
-                    <field name="image_ids" mode="kanban" />
+                    <field name="image_ids" mode="tree" nolabel="1"/>
                 </group>
             </xpath>
+        </field>
+    </record>
+
+
+    <record id="product_category_image_relation_tree" model="ir.ui.view">
+        <field name="model">category.image.relation</field>
+        <field name="arch" type="xml">
+            <tree string="Images">
+                <field name="sequence" widget="handle"/>
+                <field name="image_url" widget="image" nolabel="1" colspan="2" height="128"/>
+                <field name="image_name"/>
+                <field name="tag_id"/>
+            </tree>
         </field>
     </record>
 

--- a/storage_image_product/views/product_image_relation.xml
+++ b/storage_image_product/views/product_image_relation.xml
@@ -1,6 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
+    <record id="product_image_relation_tree" model="ir.ui.view">
+        <field name="model">product.image.relation</field>
+        <field name="arch" type="xml">
+            <tree string="Images">
+                <field name="sequence" widget="handle"/>
+                <field name="image_url" widget="image" nolabel="1" colspan="2" height="128"/>
+                <field name="image_name"/>
+                <field name="tag_id"/>
+                <field name="attribute_value_ids" widget="many2many_tags"/>
+            </tree>
+        </field>
+    </record>
+
+
     <record id="product_image_relation_form" model="ir.ui.view">
         <field name="model">product.image.relation</field>
         <field name="arch" type="xml">

--- a/storage_image_product/views/product_template.xml
+++ b/storage_image_product/views/product_template.xml
@@ -12,7 +12,7 @@
             </field>
             <xpath expr="//page[@name='sales']" position="after">
                 <page name="image" string="Image">
-                    <field name="image_ids" mode="kanban" />
+                    <field name="image_ids" mode="tree" />
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
Since 10.0 version the kanban are not orderable anymore.
So we are not able anymore to sort the image on product and category
The easiest solution is to move to a tree view
The best will be to create a new widget or to fix kanban view