### PR TITLE
[12.0] [IMP] Storage Image Product: default value of Apply On (image tag)

### DIFF
--- a/storage_image_product/models/image_tag.py
+++ b/storage_image_product/models/image_tag.py
@@ -3,13 +3,25 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ImageTag(models.Model):
     _name = "image.tag"
 
+    @api.model
+    def _get_default_apply_on(self):
+        active_model = self.env.context.get("active_model")
+        return (
+            "product"
+            if active_model == "product.image.relation"
+            else "category"
+            if active_model == "category.image.relation"
+            else False
+        )
+
     name = fields.Char()
     apply_on = fields.Selection(
-        selection=[("product", "Product"), ("category", "Category")]
+        selection=[("product", "Product"), ("category", "Category")],
+        default=lambda self: self._get_default_apply_on(),
     )

--- a/storage_image_product/views/product_category.xml
+++ b/storage_image_product/views/product_category.xml
@@ -20,7 +20,8 @@
             <form string="Association">
                 <group>
                     <field name="image_id" />
-                    <field name="tag_id"/>
+                    <field name="tag_id"
+                           context="{'active_model': context.get('active_model')}"/>
                 </group>
             </form>
         </field>

--- a/storage_image_product/views/product_image_relation.xml
+++ b/storage_image_product/views/product_image_relation.xml
@@ -7,7 +7,8 @@
             <form string="Association">
                 <group>
                     <field name="image_id"/>
-                    <field name="tag_id"/>
+                    <field name="tag_id"
+                           context="{'active_model': context.get('active_model')}"/>
                     <field name="available_attribute_value_ids" invisible="1" widget="many2many_tags"/>
                     <field
                         name="attribute_value_ids"


### PR DESCRIPTION
Add a default value for the field 'Apply On', on image tags when creating them on the fly from category.image.relation or product.image.relation.
The default value is 'product' when coming from product.image.relation and 'category' when coming from category.image.relation.
Still no default value is provided when there's no active model matching one of these two in the context.