### PR TITLE
[12.0][FIX] storage_file: Fix image_url JS

### DIFF
--- a/storage_image/static/src/js/storage_image.js
+++ b/storage_image/static/src/js/storage_image.js
@@ -8,7 +8,7 @@ odoo.define('storage_image.image_url', function (require) {
 
     var FieldImageUrl = basic_fields.FieldBinaryImage.extend({
         _render: function () {
-            // This code is an override that only change the way the rul is build
+            // This code is an override that only change the way the rule is build
             // In Odoo core if the value is not a binary, Odoo always query the
             // server on /web/image....
             var self = this;


### PR DESCRIPTION
This widget should move to https://github.com/OCA/web. An other widget with the same name and functional scope already exists but its implenetation is less complete (https://github.com/OCA/web/blob/12.0/web_widget_image_url/static/src/js/web_widget_image_url.js)