### PR TITLE
[10.0] unfreeze boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,5 @@ slugify
 vcrpy
 cerberus
 vcrpy-unittest
-# vcrp is not yet compatible with the change done in boto3
-# https://github.com/kevin1024/vcrpy/issues/382
-# for now we freeze the boto3 version
-boto3==1.7.84
-requests_mock
+boto3
+requests-mock


### PR DESCRIPTION
Because https://github.com/kevin1024/vcrpy/issues/382 is closed.

backport #84 