### PR TITLE
[12.0][IMP] Improve the way to get or create thumbnail.

### DIFF
--- a/storage_thumbnail/models/thumbnail_mixin.py
+++ b/storage_thumbnail/models/thumbnail_mixin.py
@@ -3,7 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -34,8 +35,6 @@ class ThumbnailMixing(models.AbstractModel):
 
     def get_or_create_thumbnail(self, size_x, size_y, url_key=None):
         self.ensure_one()
-        # preserve the prefetch when changing context
-        self = self.with_context(bin_size=False).with_prefetch(self._prefetch)
         if url_key:
             url_key = slugify(url_key)
         thumbnail = self.env["storage.thumbnail"].browse()
@@ -45,14 +44,23 @@ class ThumbnailMixing(models.AbstractModel):
                     continue
                 thumbnail = th
                 break
-        if not thumbnail and self.data:
+        if not thumbnail and self.file_size:
+            # We have to force real data (binary) to create thumbnail
+            self_data = self.with_context(bin_size=False).with_prefetch(
+                self._prefetch
+            )
             vals = self.env["storage.thumbnail"]._prepare_thumbnail(
-                self, size_x, size_y, url_key
+                self_data, size_x, size_y, url_key
             )
             # use the relation to create the thumbnail to be sure that the
             # record is added to the cache of this relation.
             self.write({"thumbnail_ids": [(0, 0, vals)]})
             return self.get_or_create_thumbnail(size_x, size_y, url_key)
+        elif not self.file_size:
+            raise UserError(
+                _("There is no source image to create thumbnail for: %s")
+                % self.relative_path
+            )
         return thumbnail
 
     def generate_odoo_thumbnail(self):


### PR DESCRIPTION
forward port of #80 
Actual behavior:
During access on images field, the data field is also evaluated/computed. As few line before the context is set with bin_size=False, the data computation load the real value (image) from the storage backend (sftp, etc).

Issue:
This behavior can cost a lot of time for nothing.

Improvement:
As the bin_size=True exists, it's better to use it. To know if we have a real data, the bin size is enough.
Then (into the if part), we have to load the real data value (image). So for this case we can force the context (bin_size=False).

Also, an exception has been added as the self.data (who check if the file is readable) is not triggered anymore.
