### PR TITLE
[10.0][FIX] storage_image: Allows image manager to read all storage file

### DIFF
--- a/storage_image/security/ir_rule.xml
+++ b/storage_image/security/ir_rule.xml
@@ -5,6 +5,10 @@
     <field name="name">Storage File for Image</field>
     <field name="model_id" ref="model_storage_file"/>
     <field name="domain_force">[('file_type','in', ('image', 'thumbnail'))]</field>
+    <field name="perm_read" eval="0"/>
+    <field name="perm_create" eval="1"/>
+    <field name="perm_write" eval="1"/>
+    <field name="perm_unlink" eval="1"/>
     <field name="groups" eval="[(4, ref('storage_image.group_image_manager'))]"/>
 </record>
 


### PR DESCRIPTION
Restriction on the file_type for image manager should only apply on Create Update Delete operation. Othewise an image manager is no more able to read storage.file if the file type in not in ('image', 'thumbnail')